### PR TITLE
SSP-2857 remove hasWatchStudent dependency on PersonSearchDao

### DIFF
--- a/src/main/java/org/jasig/ssp/dao/PersonSearchDao.java
+++ b/src/main/java/org/jasig/ssp/dao/PersonSearchDao.java
@@ -432,15 +432,17 @@ public class PersonSearchDao extends AbstractDao<Person> {
 			}			
 		}
 		
-		if(hasCoach(personSearchRequest) || hasMyCaseload(personSearchRequest) || hasWatchStudent(personSearchRequest))
+		if(hasCoach(personSearchRequest) || hasMyCaseload(personSearchRequest))
 		{
 			Person coach = personSearchRequest.getMyCaseload() != null && personSearchRequest.getMyCaseload() ? securityService.currentlyAuthenticatedUser().getPerson() : personSearchRequest.getCoach();
-			if(coach == null && personSearchRequest.getMyWatchList() != null && personSearchRequest.getMyWatchList())
-			{
-				coach = securityService.currentlyAuthenticatedUser().getPerson();
-			}
 			query.setEntity("coach", coach);
 		}
+		
+		if(hasWatchStudent(personSearchRequest))
+		{
+			Person watcher = personSearchRequest.getMyWatchList() != null && personSearchRequest.getMyWatchList() ? securityService.currentlyAuthenticatedUser().getPerson() : personSearchRequest.getWatcher();
+			query.setEntity("watcher", watcher);
+		}		
 		
 		if(hasDeclaredMajor(personSearchRequest))
 		{


### PR DESCRIPTION
myWatchList and myCaseload interfere with each other.  myCaseload takes precedence.  Code update now respects both parameters (uses the "watcher" query parameter.  However, parameters are additive, so the likelyhood of a query where the person who is searching only wants students that are both on myCaseload AND on myWatchList may be small.
